### PR TITLE
Updated .gitignore to include node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 pkg/
 wasm-pack.log
 worker/generated/
+node_modules/


### PR DESCRIPTION
Small fix to add `node_modules/` to the `.gitignore`. See issue #7 