### PR TITLE
Make workers private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "{{ project-name }}",
   "version": "1.0.0",
   "description": "A template for kick starting a Cloudflare Workers project",


### PR DESCRIPTION
Without this, it is way too easy to accidentally publish your internal worker code to the public npm registry, it happened to us :-D