### PR TITLE
chore(package.json): move prettier to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "author": "{{ authors }}",
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "prettier": "^1.18.2"
   }
 }


### PR DESCRIPTION
Generally prettier and other such tools are placed in `devDependencies`