### PR TITLE
Ignore dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/dist
 **/*.rs.bk
 Cargo.lock
 bin/


### PR DESCRIPTION
This directory will be created if someone changes the `type` to `webpack`, so it should be ignored in `.gitignore` by default.