### PR TITLE
Update prettier major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "author": "{{ authors }}",
   "license": "MIT",
   "devDependencies": {
-    "prettier": "^1.18.2"
+    "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
The latest major version of `prettier` is ` v2.2.1`.

I think a lot of people, including myself, are using `v2.x` these days, so I thought it would be better to update this template as well.

(I've spent a few hours to find [this feature](https://prettier.io/blog/2020/03/21/2.0.0.html#expand-directories-including--7660httpsgithubcomprettierprettierpull7660-by-thorn0httpsgithubcomthorn0) not working... 😅 )